### PR TITLE
Makefile changes

### DIFF
--- a/makefile
+++ b/makefile
@@ -74,10 +74,18 @@ all: $(OUTPUTDIR) libJyNI libJyNI-Loader JyNI
 debug: CFLAGS += -g
 debug: all
 
+clean:
+	rm -rf $(JYNIBIN)
+	rm -f ./JyNI-C/src/*.o
+	rm -f ./JyNI-C/src/Python/*.o
+	rm -f ./JyNI-C/src/Objects/*.o
+	rm -f ./JyNI-C/src/Modules/*.o
+	rm -f ./JyNI-Loader/JyNILoader.o
+
 tests: build-tests run-tests
 
 build-tests:
-	@echo 'building tests is not fully supported yet, this will either not work or install the demo extension as an actuall extension'
+	@echo 'building tests is not fully supported yet, this will either not work or try to install the demo extension as an actuall extension'
 	python ./DemoExtension/setup.py install
 	
 run-tests:
@@ -121,11 +129,24 @@ ifeq "$(wildcard $(JAVA_HOME) )" ""
 	$(eval JAVA_HOME = $(shell $(JAVA) -jar $(JYTHON) -c "from java.lang import System; print System.getProperty('java.home')[:-4]"))
 endif
 
+# assume you want debug if you are just compiling one portion of the codebase
+libJyNI:  CFLAGS += -g
 libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
 	$(CC) $(LDFLAGS) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o -o $(OUTPUTDIR)/libJyNI.so
 
+cleanC:
+	rm -f ./JyNI-C/src/*.o
+	rm -f ./JyNI-C/src/Python/*.o
+	rm -f ./JyNI-C/src/Objects/*.o
+	rm -f ./JyNI-C/src/Modules/*.o
+
+# assume you want debug if you are just compiling one portion of the codebase
+libJyNI-Loader:  CFLAGS += -g
 libJyNI-Loader: $(JAVA_HOME) JyNI-Loader/JyNILoader.o
 	$(CC) $(LDFLAGS) ./JyNI-Loader/JyNILoader.o -o $(OUTPUTDIR)/libJyNI-Loader.so
+
+cleanLoader:
+	rm -f ./JyNI-Loader/JyNILoader.o
 
 $(JYNIBIN):
 	mkdir $(JYNIBIN)
@@ -144,13 +165,5 @@ JyNI: $(JYTHON) $(JYNIBIN)/JyNI $(JYNIBIN)/Lib
 cleanJ:
 	rm -rf $(JYNIBIN)
 
-clean:
-	rm -rf $(JYNIBIN)
-	rm -f ./JyNI-C/src/*.o
-	rm -f ./JyNI-C/src/Python/*.o
-	rm -f ./JyNI-C/src/Objects/*.o
-	rm -f ./JyNI-C/src/Modules/*.o
-	rm -f ./JyNI-Loader/JyNILoader.o
-
-.PHONY: JyNI libJyNI libJyNI-Loader clean cleanJ JAVA_HOME_hint all debug tests run-tests build-tests
+.PHONY: JyNI libJyNI libJyNI-Loader clean cleanC cleanLoader cleanJ JAVA_HOME_hint all debug tests run-tests build-tests
 

--- a/makefile
+++ b/makefile
@@ -84,9 +84,9 @@ clean:
 
 tests: build-tests run-tests
 
+# each line is in a subshell so this must be all on one line, also we don't need to cd back up at the end
 build-tests:
-	@echo 'building tests is not fully supported yet, this will either not work or try to install the demo extension as an actuall extension'
-	python ./DemoExtension/setup.py install
+	cd /scratch/calum/JyNI_summer/JyNI/DemoExtension && python ./setup.py build || echo "" && echo "Building tests failed"
 	
 run-tests:
 	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py
@@ -129,23 +129,26 @@ ifeq "$(wildcard $(JAVA_HOME) )" ""
 	$(eval JAVA_HOME = $(shell $(JAVA) -jar $(JYTHON) -c "from java.lang import System; print System.getProperty('java.home')[:-4]"))
 endif
 
-# assume you want debug if you are just compiling one portion of the codebase
 libJyNI:  CFLAGS += -g
 libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
 	$(CC) $(LDFLAGS) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o -o $(OUTPUTDIR)/libJyNI.so
 
-cleanC:
+debug-libJyNI: CFLAGS += -g
+debug-libJyNI: libJyNI
+
+clean-libJyNI:
 	rm -f ./JyNI-C/src/*.o
 	rm -f ./JyNI-C/src/Python/*.o
 	rm -f ./JyNI-C/src/Objects/*.o
 	rm -f ./JyNI-C/src/Modules/*.o
 
-# assume you want debug if you are just compiling one portion of the codebase
-libJyNI-Loader:  CFLAGS += -g
 libJyNI-Loader: $(JAVA_HOME) JyNI-Loader/JyNILoader.o
 	$(CC) $(LDFLAGS) ./JyNI-Loader/JyNILoader.o -o $(OUTPUTDIR)/libJyNI-Loader.so
 
-cleanLoader:
+debug-libJyNI-Loader: CFLAGS += -g
+debug-libJyNI-Loader: libJyNI-Loader
+
+clean-libJyNI-Loader:
 	rm -f ./JyNI-Loader/JyNILoader.o
 
 $(JYNIBIN):
@@ -165,5 +168,5 @@ JyNI: $(JYTHON) $(JYNIBIN)/JyNI $(JYNIBIN)/Lib
 cleanJ:
 	rm -rf $(JYNIBIN)
 
-.PHONY: JyNI libJyNI libJyNI-Loader clean cleanC cleanLoader cleanJ JAVA_HOME_hint all debug tests run-tests build-tests
+.PHONY: all debug clean libJyNI debug-libJyNI clean-libJyNI libJyNI-Loader debug-libJyNI-Loader clean-libJyNI-Loader JyNI cleanJ JAVA_HOME_hint tests run-tests build-tests
 

--- a/makefile
+++ b/makefile
@@ -67,7 +67,7 @@ SOURCES = $(wildcard JyNI-C/src/*.c) $(wildcard JyNI-C/src/Python/*.c) $(wildcar
 OBJECTS = $(SOURCES:.c=.o)
 JSOURCES = $(wildcard JyNI-Java/src/JyNI/*.java) $(wildcard JyNI-Java/src/JyNI/gc/*.java)
 
-all: $(OUTPUTDIR) libJyNI libJyNI-Loader JyNI
+all: $(OUTPUTDIR) _libJyNI _libJyNI-Loader JyNI
 	@echo ''
 	@echo 'Build successful.'
 
@@ -129,11 +129,11 @@ ifeq "$(wildcard $(JAVA_HOME) )" ""
 	$(eval JAVA_HOME = $(shell $(JAVA) -jar $(JYTHON) -c "from java.lang import System; print System.getProperty('java.home')[:-4]"))
 endif
 
-libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
+_libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
 	$(CC) $(LDFLAGS) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o -o $(OUTPUTDIR)/libJyNI.so
 
-debug-libJyNI: CFLAGS += -g
-debug-libJyNI: libJyNI
+libJyNI: CFLAGS += -g
+libJyNI: _libJyNI
 
 clean-libJyNI:
 	rm -f ./JyNI-C/src/*.o
@@ -141,11 +141,11 @@ clean-libJyNI:
 	rm -f ./JyNI-C/src/Objects/*.o
 	rm -f ./JyNI-C/src/Modules/*.o
 
-libJyNI-Loader: $(JAVA_HOME) JyNI-Loader/JyNILoader.o
+_libJyNI-Loader: $(JAVA_HOME) JyNI-Loader/JyNILoader.o
 	$(CC) $(LDFLAGS) ./JyNI-Loader/JyNILoader.o -o $(OUTPUTDIR)/libJyNI-Loader.so
 
-debug-libJyNI-Loader: CFLAGS += -g
-debug-libJyNI-Loader: libJyNI-Loader
+libJyNI-Loader: CFLAGS += -g
+libJyNI-Loader: _libJyNI-Loader
 
 clean-libJyNI-Loader:
 	rm -f ./JyNI-Loader/JyNILoader.o
@@ -167,5 +167,5 @@ JyNI: $(JYTHON) $(JYNIBIN)/JyNI $(JYNIBIN)/Lib
 cleanJ:
 	rm -rf $(JYNIBIN)
 
-.PHONY: all debug clean libJyNI debug-libJyNI clean-libJyNI libJyNI-Loader debug-libJyNI-Loader clean-libJyNI-Loader JyNI cleanJ JAVA_HOME_hint tests run-tests build-tests
+.PHONY: all debug clean _libJyNI libJyNI clean-libJyNI _libJyNI-Loader libJyNI-Loader clean-libJyNI-Loader JyNI cleanJ JAVA_HOME_hint tests run-tests build-tests
 

--- a/makefile
+++ b/makefile
@@ -74,8 +74,14 @@ all: $(OUTPUTDIR) libJyNI libJyNI-Loader JyNI
 debug: CFLAGS += -g
 debug: all
 
-tests:
-	@echo 'Tests have not been implemented yet'
+tests: build-tests run-tests
+
+build-tests:
+	@echo 'building tests is not fully supported yet, this will either not work or install the demo extension as an actuall extension'
+	python ./DemoExtension/setup.py install
+	
+run-tests:
+	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py
 
 $(OUTPUTDIR):
 	mkdir $(OUTPUTDIR)
@@ -146,5 +152,5 @@ clean:
 	rm -f ./JyNI-C/src/Modules/*.o
 	rm -f ./JyNI-Loader/JyNILoader.o
 
-.PHONY: JyNI libJyNI libJyNI-Loader clean cleanJ JAVA_HOME_hint all debug tests
+.PHONY: JyNI libJyNI libJyNI-Loader clean cleanJ JAVA_HOME_hint all debug tests run-tests build-tests
 

--- a/makefile
+++ b/makefile
@@ -86,7 +86,7 @@ tests: build-tests run-tests
 
 # each line is in a subshell so this must be all on one line, also we don't need to cd back up at the end
 build-tests:
-	cd /scratch/calum/JyNI_summer/JyNI/DemoExtension && python ./setup.py build || echo "" && echo "Building tests failed"
+	cd ./DemoExtension && python ./setup.py build || echo "" && echo "Building tests failed"
 	
 run-tests:
 	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py
@@ -129,7 +129,6 @@ ifeq "$(wildcard $(JAVA_HOME) )" ""
 	$(eval JAVA_HOME = $(shell $(JAVA) -jar $(JYTHON) -c "from java.lang import System; print System.getProperty('java.home')[:-4]"))
 endif
 
-libJyNI:  CFLAGS += -g
 libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
 	$(CC) $(LDFLAGS) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o -o $(OUTPUTDIR)/libJyNI.so
 

--- a/makefile
+++ b/makefile
@@ -86,7 +86,7 @@ tests: build-tests run-tests
 
 # each line is in a subshell so this must be all on one line, also we don't need to cd back up at the end
 build-tests:
-	cd ./DemoExtension && python ./setup.py build || echo "" && echo "Building tests failed"
+	cd ./DemoExtension && python ./setup.py build || echo "Building tests failed"
 	
 run-tests:
 	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py

--- a/makefile.clang
+++ b/makefile.clang
@@ -70,6 +70,26 @@ all: $(OUTPUTDIR) libJyNI libJyNI-Loader JyNI
 	@echo ''
 	@echo 'Build successful.'
 
+debug: CFLAGS += -g
+debug: all
+
+clean:
+	rm -rf $(JYNIBIN)
+	rm -f ./JyNI-C/src/*.o
+	rm -f ./JyNI-C/src/Python/*.o
+	rm -f ./JyNI-C/src/Objects/*.o
+	rm -f ./JyNI-C/src/Modules/*.o
+	rm -f ./JyNI-Loader/JyNILoader.o
+
+tests: build-tests run-tests
+
+build-tests:
+	@echo 'building tests is not fully supported yet, this will either not work or try to install the demo extension as an actuall extension'
+	python ./DemoExtension/setup.py install
+	
+run-tests:
+	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py
+
 $(OUTPUTDIR):
 	mkdir $(OUTPUTDIR)
 
@@ -108,11 +128,24 @@ ifeq "$(wildcard $(JAVA_HOME) )" ""
 	$(eval JAVA_HOME = $(shell $(JAVA) -jar $(JYTHON) -c "from java.lang import System; print System.getProperty('java.home')[:-4]"))
 endif
 
+# assume you want debug if you are just compiling one portion of the codebase
+libJyNI:  CFLAGS += -g
 libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
 	$(CC) $(LDFLAGS) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o -o $(OUTPUTDIR)/libJyNI.so
 
+cleanC:
+	rm -f ./JyNI-C/src/*.o
+	rm -f ./JyNI-C/src/Python/*.o
+	rm -f ./JyNI-C/src/Objects/*.o
+	rm -f ./JyNI-C/src/Modules/*.o
+
+# assume you want debug if you are just compiling one portion of the codebase
+libJyNI-Loader:  CFLAGS += -g
 libJyNI-Loader: $(JAVA_HOME) ./JyNI-Loader/JyNILoader.o
 	$(CC) $(LDFLAGS) ./JyNI-Loader/JyNILoader.o -o $(OUTPUTDIR)/libJyNI-Loader.so
+
+cleanLoader:
+	rm -f ./JyNI-Loader/JyNILoader.o
 
 $(JYNIBIN):
 	mkdir $(JYNIBIN)
@@ -131,13 +164,5 @@ JyNI: $(JYTHON) $(JYNIBIN)/JyNI $(JYNIBIN)/Lib
 cleanJ:
 	rm -rf $(JYNIBIN)
 
-clean:
-	rm -rf $(JYNIBIN)
-	rm -f ./JyNI-C/src/*.o
-	rm -f ./JyNI-C/src/Python/*.o
-	rm -f ./JyNI-C/src/Objects/*.o
-	rm -f ./JyNI-C/src/Modules/*.o
-	rm -f ./JyNI-Loader/JyNILoader.o
-
-.PHONY: JyNI libJyNI libJyNI-Loader clean cleanJ JAVA_HOME_hint all
+.PHONY: JyNI libJyNI libJyNI-Loader clean cleanC cleanLoader cleanJ JAVA_HOME_hint all debug tests run-tests build-tests
 

--- a/makefile.clang
+++ b/makefile.clang
@@ -84,8 +84,7 @@ clean:
 tests: build-tests run-tests
 
 build-tests:
-	@echo 'building tests is not fully supported yet, this will either not work or try to install the demo extension as an actuall extension'
-	python ./DemoExtension/setup.py install
+	cd ./DemoExtension && python ./setup.py build || echo "" && echo "Building tests failed"
 	
 run-tests:
 	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py
@@ -128,23 +127,25 @@ ifeq "$(wildcard $(JAVA_HOME) )" ""
 	$(eval JAVA_HOME = $(shell $(JAVA) -jar $(JYTHON) -c "from java.lang import System; print System.getProperty('java.home')[:-4]"))
 endif
 
-# assume you want debug if you are just compiling one portion of the codebase
-libJyNI:  CFLAGS += -g
 libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
 	$(CC) $(LDFLAGS) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o -o $(OUTPUTDIR)/libJyNI.so
 
-cleanC:
+debug-libJyNI: CFLAGS += -g
+debug-libJyNI: libJyNI
+
+clean-libJyNI:
 	rm -f ./JyNI-C/src/*.o
 	rm -f ./JyNI-C/src/Python/*.o
 	rm -f ./JyNI-C/src/Objects/*.o
 	rm -f ./JyNI-C/src/Modules/*.o
 
-# assume you want debug if you are just compiling one portion of the codebase
-libJyNI-Loader:  CFLAGS += -g
 libJyNI-Loader: $(JAVA_HOME) ./JyNI-Loader/JyNILoader.o
 	$(CC) $(LDFLAGS) ./JyNI-Loader/JyNILoader.o -o $(OUTPUTDIR)/libJyNI-Loader.so
 
-cleanLoader:
+debug-libJyNI-Loader: CFLAGS += -g
+debug-libJyNI-Loader: libJyNI-Loader
+
+clean-libJyNI-Loader:
 	rm -f ./JyNI-Loader/JyNILoader.o
 
 $(JYNIBIN):
@@ -164,5 +165,5 @@ JyNI: $(JYTHON) $(JYNIBIN)/JyNI $(JYNIBIN)/Lib
 cleanJ:
 	rm -rf $(JYNIBIN)
 
-.PHONY: JyNI libJyNI libJyNI-Loader clean cleanC cleanLoader cleanJ JAVA_HOME_hint all debug tests run-tests build-tests
+.PHONY: all debug clean libJyNI debug-libJyNI clean-libJyNI libJyNI-Loader debug-libJyNI-Loader clean-libJyNI-Loader JyNI cleanJ JAVA_HOME_hint tests run-tests build-tests
 

--- a/makefile.clang
+++ b/makefile.clang
@@ -84,7 +84,7 @@ clean:
 tests: build-tests run-tests
 
 build-tests:
-	cd ./DemoExtension && python ./setup.py build || echo "" && echo "Building tests failed"
+	cd ./DemoExtension && python ./setup.py build || echo "Building tests failed"
 	
 run-tests:
 	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py

--- a/makefile.osx
+++ b/makefile.osx
@@ -80,8 +80,7 @@ clean:
 tests: build-tests run-tests
 
 build-tests:
-	@echo 'building tests is not fully supported yet, this will either not work or try to install the demo extension as an actuall extension'
-	python ./DemoExtension/setup.py install
+	cd ./DemoExtension && python ./setup.py build || echo "" && echo "Building tests failed"
 	
 run-tests:
 	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py
@@ -124,23 +123,25 @@ ifeq "$(wildcard $(JAVA_HOME) )" ""
 	$(eval JAVA_HOME = $(shell $(JAVA) -jar $(JYTHON) -c "from java.lang import System; print System.getProperty('java.home')[:-4]"))
 endif
 
-# assume you want debug if you are just compiling one portion of the codebase
-libJyNI:  CFLAGS += -g
 libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
 	$(CC) $(LDFLAGS) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o -o $(OUTPUTDIR)/libJyNI.dylib
 
-cleanC:
+debug-libJyNI: CFLAGS += -g
+debug-libJyNI: libJyNI
+
+clean-libJyNI:
 	rm -f ./JyNI-C/src/*.o
 	rm -f ./JyNI-C/src/Python/*.o
 	rm -f ./JyNI-C/src/Objects/*.o
 	rm -f ./JyNI-C/src/Modules/*.o
 
-# assume you want debug if you are just compiling one portion of the codebase
-libJyNI-Loader:  CFLAGS += -g
 libJyNI-Loader: $(JAVA_HOME) ./JyNI-Loader/JyNILoader.o
 	$(CC) $(LDFLAGS) ./JyNI-Loader/JyNILoader.o -o $(OUTPUTDIR)/libJyNI-Loader.dylib
 
-cleanLoader:
+debug-libJyNI-Loader: CFLAGS += -g
+debug-libJyNI-Loader: libJyNI-Loader
+
+clean-libJyNI-Loader:
 	rm -f ./JyNI-Loader/JyNILoader.o
 
 $(JYNIBIN):
@@ -160,5 +161,5 @@ JyNI: $(JYTHON) $(JYNIBIN)/JyNI $(JYNIBIN)/Lib
 cleanJ:
 	rm -rf $(JYNIBIN)
 
-.PHONY: JyNI libJyNI libJyNI-Loader clean cleanC cleanLoader cleanJ JAVA_HOME_hint all debug tests run-tests build-tests
+.PHONY: all debug clean libJyNI debug-libJyNI clean-libJyNI libJyNI-Loader debug-libJyNI-Loader clean-libJyNI-Loader JyNI cleanJ JAVA_HOME_hint tests run-tests build-tests
 

--- a/makefile.osx
+++ b/makefile.osx
@@ -80,7 +80,7 @@ clean:
 tests: build-tests run-tests
 
 build-tests:
-	cd ./DemoExtension && python ./setup.py build || echo "" && echo "Building tests failed"
+	cd ./DemoExtension && python ./setup.py build || echo "Building tests failed"
 	
 run-tests:
 	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py

--- a/makefile.osx
+++ b/makefile.osx
@@ -66,6 +66,26 @@ all: $(OUTPUTDIR) libJyNI libJyNI-Loader JyNI
 	@echo ''
 	@echo 'Build successful.'
 
+debug: CFLAGS += -g
+debug: all
+
+clean:
+	rm -rf $(JYNIBIN)
+	rm -f ./JyNI-C/src/*.o
+	rm -f ./JyNI-C/src/Python/*.o
+	rm -f ./JyNI-C/src/Objects/*.o
+	rm -f ./JyNI-C/src/Modules/*.o
+	rm -f ./JyNI-Loader/JyNILoader.o
+
+tests: build-tests run-tests
+
+build-tests:
+	@echo 'building tests is not fully supported yet, this will either not work or try to install the demo extension as an actuall extension'
+	python ./DemoExtension/setup.py install
+	
+run-tests:
+	java -Djava.library.path=./build/ -cp $(JYTHON):./build/JyNI.jar org.python.util.jython ./JyNI-Demo/src/test_all.py
+
 $(OUTPUTDIR):
 	mkdir $(OUTPUTDIR)
 
@@ -104,11 +124,24 @@ ifeq "$(wildcard $(JAVA_HOME) )" ""
 	$(eval JAVA_HOME = $(shell $(JAVA) -jar $(JYTHON) -c "from java.lang import System; print System.getProperty('java.home')[:-4]"))
 endif
 
+# assume you want debug if you are just compiling one portion of the codebase
+libJyNI:  CFLAGS += -g
 libJyNI: $(JAVA_HOME) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o
 	$(CC) $(LDFLAGS) $(OBJECTS) JyNI-C/src/Python/dynload_shlib.o -o $(OUTPUTDIR)/libJyNI.dylib
 
+cleanC:
+	rm -f ./JyNI-C/src/*.o
+	rm -f ./JyNI-C/src/Python/*.o
+	rm -f ./JyNI-C/src/Objects/*.o
+	rm -f ./JyNI-C/src/Modules/*.o
+
+# assume you want debug if you are just compiling one portion of the codebase
+libJyNI-Loader:  CFLAGS += -g
 libJyNI-Loader: $(JAVA_HOME) ./JyNI-Loader/JyNILoader.o
 	$(CC) $(LDFLAGS) ./JyNI-Loader/JyNILoader.o -o $(OUTPUTDIR)/libJyNI-Loader.dylib
+
+cleanLoader:
+	rm -f ./JyNI-Loader/JyNILoader.o
 
 $(JYNIBIN):
 	mkdir $(JYNIBIN)
@@ -127,13 +160,5 @@ JyNI: $(JYTHON) $(JYNIBIN)/JyNI $(JYNIBIN)/Lib
 cleanJ:
 	rm -rf $(JYNIBIN)
 
-clean:
-	rm -rf $(JYNIBIN)
-	rm -f ./JyNI-C/src/*.o
-	rm -f ./JyNI-C/src/Python/*.o
-	rm -f ./JyNI-C/src/Objects/*.o
-	rm -f ./JyNI-C/src/Modules/*.o
-	rm -f ./JyNI-Loader/JyNILoader.o
-
-.PHONY: JyNI libJyNI libJyNI-Loader clean cleanJ JAVA_HOME_hint all
+.PHONY: JyNI libJyNI libJyNI-Loader clean cleanC cleanLoader cleanJ JAVA_HOME_hint all debug tests run-tests build-tests
 


### PR DESCRIPTION
Debug and test modes have been built, and there are now builds and cleans for each of the separate eclipse projects, that way you can configure the builds properly in eclipse.

I've also updated the makefile.clan and makefile.osx but I'm not sure how to deal with the windows build.
